### PR TITLE
Relax infomap version requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pybind11>=2.4
-infomap==1.0.6
+infomap>=1.0.6,<3
 folium>=0.7.0
 numpy
 tqdm

--- a/setup.py
+++ b/setup.py
@@ -114,7 +114,7 @@ setup(
     setup_requires=["pybind11>=2.4"],
     install_requires=[
         "pybind11>=2.4",
-        "infomap==1.0.6",
+        "infomap>=1.0.6,<3",
         "folium>=0.7.0",
         "numpy",
         "tqdm",


### PR DESCRIPTION
This is what I've used as part of https://github.com/easybuilders/easybuild-easyconfigs/pull/17988. Related to https://github.com/ulfaslak/infostop/issues/23.

I've seen no issue with Infomap==2.7.1 but this is in no way exhaustively tested.